### PR TITLE
added functionality to extract tuples into multiple parameters

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -122,7 +122,10 @@ def ddt(cls):
         if hasattr(func, DATA_ATTR):
             for v in getattr(func, DATA_ATTR):
                 test_name = mk_test_name(name, getattr(v, "__name__", v))
-                setattr(cls, test_name, feed_data(func, v))
+                if type(v) is tuple:
+                    setattr(cls, test_name, feed_data(func, *v))
+                else:
+                    setattr(cls, test_name, feed_data(func, v))
             delattr(cls, name)
         elif hasattr(func, FILE_ATTR):
             file_attr = getattr(func, FILE_ATTR)

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -1,6 +1,6 @@
 import unittest
 from ddt import ddt, data, file_data
-from .mycode import larger_than_two, has_three_elements, is_a_greeting
+from test.mycode import larger_than_two, has_three_elements, is_a_greeting
 
 
 class mylist(list):
@@ -15,7 +15,6 @@ def annotated(a, b):
 
 @ddt
 class FooTestCase(unittest.TestCase):
-
     def test_undecorated(self):
         self.assertTrue(larger_than_two(24))
 
@@ -39,6 +38,10 @@ class FooTestCase(unittest.TestCase):
     @file_data('test_data_list.json')
     def test_file_data_list(self, value):
         self.assertTrue(is_a_greeting(value))
+
+    @data((3, 2), (4, 3), (5, 3))
+    def test_tuples_extracted_into_multiple_arguments(self, first_value, second_value):
+        self.assertTrue(first_value > second_value)
 
     @data(u'ascii', u'non-ascii-\N{SNOWMAN}')
     def test_unicode(self, value):


### PR DESCRIPTION
I have added extraction into multiple parameters for test methods
here is an example

``` python
@data(
        ((1, 0), FOOTBALL_1_0),
        ((2, 0), FOOTBALL_2_0),
        ((0, 1), FOOTBALL_0_1),
        ((0, 2), FOOTBALL_0_2),
        ((0, 0), FOOTBALL_0_0),
        ((1, 1), FOOTBALL_1_1),
    )
def test_football(self, score, winnings):
     self._set_game_score(score[0], score[1])
     self.calculator.calculate()
     self._assert_winnings(winnings)
```
