### PR TITLE
Unpack feature

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -11,6 +11,14 @@ DATA_ATTR = '%values'
 # store the path to JSON file
 FILE_ATTR = '%file_path'
 
+UNPACK_ATTR = '%unpack'
+
+def unpack(func):
+    """
+    Method decorator to add unpack feature
+    """
+    setattr(func, UNPACK_ATTR, True)
+    return func
 
 def data(*values):
     """
@@ -122,8 +130,11 @@ def ddt(cls):
         if hasattr(func, DATA_ATTR):
             for v in getattr(func, DATA_ATTR):
                 test_name = mk_test_name(name, getattr(v, "__name__", v))
-                if type(v) is tuple:
-                    setattr(cls, test_name, feed_data(func, *v))
+                if hasattr(func, UNPACK_ATTR):
+                    if type(v) is tuple or type(v) is list:
+                        setattr(cls, test_name, feed_data(func, *v))
+                    else:
+                        setattr(cls, test_name, feed_data(func, **v))
                 else:
                     setattr(cls, test_name, feed_data(func, v))
             delattr(cls, name)

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -1,5 +1,5 @@
 import unittest
-from ddt import ddt, data, file_data
+from ddt import ddt, data, file_data, unpack
 from test.mycode import larger_than_two, has_three_elements, is_a_greeting
 
 
@@ -40,8 +40,20 @@ class FooTestCase(unittest.TestCase):
         self.assertTrue(is_a_greeting(value))
 
     @data((3, 2), (4, 3), (5, 3))
+    @unpack
     def test_tuples_extracted_into_multiple_arguments(self, first_value, second_value):
         self.assertTrue(first_value > second_value)
+
+    @data([3, 2], [4, 3], [5, 3])
+    @unpack
+    def test_list_extracted_into_multiple_arguments(self, first_value, second_value):
+        self.assertTrue(first_value > second_value)
+
+    @unpack
+    @data({'first': 1, 'second': 3, 'third': 2}, {'first': 4, 'second': 6, 'third': 5})
+    def test_extraction_into_kwargs(self, first, second, third):
+        self.assertTrue(first < third < second)
+
 
     @data(u'ascii', u'non-ascii-\N{SNOWMAN}')
     def test_unicode(self, value):


### PR DESCRIPTION
I have added unpack decorator that can work with tuples, lists and dictionaries
examples can be found in the test/test_example.py
This relates to ticket https://github.com/txels/ddt/issues/3
