### PR TITLE
Add nested dict example to docs and cosmetic adjustments

### DIFF
--- a/docs/example.rst
+++ b/docs/example.rst
@@ -29,18 +29,25 @@ Where ``test_data_dict_dict.json``:
 .. literalinclude:: ../test/test_data_dict_dict.json
    :language: javascript
 
+and ``test_data_dict_dict.yaml``:
+
+.. literalinclude:: ../test/test_data_dict_dict.yaml
+   :language: yaml
+
 and ``test_data_dict.json``:
 
 .. literalinclude:: ../test/test_data_dict.json
    :language: javascript
 
+and ``test_data_dict.yaml``:
+
+.. literalinclude:: ../test/test_data_dict.yaml
+   :language: yaml
+
 and ``test_data_list.json``:
 
 .. literalinclude:: ../test/test_data_list.json
    :language: javascript
-
-.. literalinclude:: ../test/test_data_dict.yaml
-   :language: yaml
 
 and ``test_data_list.yaml``:
 

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -24,7 +24,12 @@ This allows you to write your tests as:
 .. literalinclude:: ../test/test_example.py
    :language: python
 
-Where ``test_data_dict.json``:
+Where ``test_data_dict_dict.json``:
+
+.. literalinclude:: ../test/test_data_dict_dict.json
+   :language: javascript
+
+and ``test_data_dict.json``:
 
 .. literalinclude:: ../test/test_data_dict.json
    :language: javascript


### PR DESCRIPTION
When I went through examples here: http://ddt.readthedocs.io/en/latest/example.html
I've noticed that the content of the `test_data_dict_dict` yaml/json files is not shown, so I had to go to the source code to check it out.

Also, under `test_data_list.json` there is json list and **yaml dict** example, so I moved it above where `test_data_dict.json` is.