### PR TITLE
GitHub and badges URL updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/txels/ddt.svg)](https://travis-ci.org/txels/ddt)
+[![Build Status](https://travis-ci.org/datadriventests/ddt.svg)](https://travis-ci.org/datadriventests/ddt)
 [![Code Health](https://landscape.io/github/txels/ddt/master/landscape.svg)](https://landscape.io/github/txels/ddt/master)
-[![codecov.io](https://codecov.io/github/txels/ddt/coverage.svg?branch=master)](https://codecov.io/github/txels/ddt)
+[![codecov.io](https://codecov.io/github/datadriventests/ddt/coverage.svg?branch=master)](https://codecov.io/github/datadriventests/ddt)
 <br />
 [![Version](https://img.shields.io/pypi/v/ddt.svg)](https://pypi.python.org/pypi/ddt)
 [![Downloads](https://img.shields.io/pypi/dm/ddt.svg)](https://pypi.python.org/pypi/ddt)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/datadriventests/ddt.svg)](https://travis-ci.org/datadriventests/ddt)
-[![Code Health](https://landscape.io/github/txels/ddt/master/landscape.svg)](https://landscape.io/github/txels/ddt/master)
 [![codecov.io](https://codecov.io/github/datadriventests/ddt/coverage.svg?branch=master)](https://codecov.io/github/datadriventests/ddt)
 <br />
 [![Version](https://img.shields.io/pypi/v/ddt.svg)](https://pypi.python.org/pypi/ddt)

--- a/ddt.py
+++ b/ddt.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is a part of DDT (https://github.com/txels/ddt)
+# This file is a part of DDT (https://github.com/datadriventests/ddt)
 # Copyright 2012-2015 Carles Barrobés and DDT contributors
 # For the exact contribution history, see the git revision log.
 # DDT is licensed under the MIT License, included in
-# https://github.com/txels/ddt/blob/master/LICENSE.md
+# https://github.com/datadriventests/ddt/blob/master/LICENSE.md
 
 import inspect
 import json

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,4 +27,4 @@ Indices and tables
 * :ref:`search`
 
 
-.. _Github: https://github.com/txels/ddt
+.. _Github: https://github.com/datadriventests/ddt

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version=__version__,
     author='Carles Barrobés',
     author_email='carles@barrobes.com',
-    url='https://github.com/txels/ddt',
+    url='https://github.com/datadriventests/ddt',
     py_modules=['ddt'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
I haven't updated the https://landscape.io/ badge, because for the past couple weeks it's been a static site with simply the text "Back soon…". The site is now timing out, so the badge should probably be removed instead.