### PR TITLE
Allow index-only test names

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,4 @@
 -r test.txt
-
+nose
 Sphinx
 sphinxcontrib-programoutput

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from ddt import ddt, data, file_data
 from nose.tools import (
-    assert_true, assert_equal, assert_is_not_none, assert_raises
+    assert_true, assert_equal, assert_false, assert_is_not_none, assert_raises
 )
 
 from test.mycode import has_three_elements
@@ -32,11 +32,23 @@ class Dummy(object):
         return value
 
 
+@ddt(indexOnly=True)
+class DummyIndexOnlyTestNames(object):
+    """
+    Dummy class to test the ddt decorator that generates test names using only
+    the index.
+    """
+
+    @data("a", "b", "c", "d")
+    def test_something(self, value):
+        return value
+
+
 @ddt
 class DummyInvalidIdentifier():
     """
     Dummy class to test the data decorator receiving values invalid characters
-    indentifiers
+    identifiers
     """
 
     @data('32v2 g #Gmw845h$W b53wi.')
@@ -132,6 +144,20 @@ def test_ddt():
     """
     tests = len(list(filter(_is_test, Dummy.__dict__)))
     assert_equal(tests, 4)
+
+
+def test_ddt_index_only_true():
+    """
+    Test the ``ddt`` class decorator with kwargs ``indexOnly=True``
+    """
+    tests = set(filter(_is_test, DummyIndexOnlyTestNames.__dict__))
+    assert_equal(len(tests), 4)
+
+    indexes = range(1, 5)
+    dataSets = ["a", "b", "c", "d"]  # @data inside DummyIndexOnlyTestNames
+    for i, d in zip(indexes, dataSets):
+        assert_true("test_something_{}".format(i) in tests)
+        assert_false("test_something_{}_{}".format(i, d) in tests)
 
 
 def test_file_data_test_creation():

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import mock
 
-from ddt import ddt, data, file_data
+from ddt import ddt, data, file_data, FormatTestName
 from nose.tools import (
     assert_true, assert_equal, assert_false, assert_is_not_none, assert_raises
 )
@@ -32,8 +32,20 @@ class Dummy(object):
         return value
 
 
-@ddt(indexOnly=True)
-class DummyIndexOnlyTestNames(object):
+@ddt(formatTestName=FormatTestName.DEFAULT)
+class DummyFormatTestNameDefault(object):
+    """
+    Dummy class to test the ddt decorator that generates test names using the
+    default format (index and values).
+    """
+
+    @data("a", "b", "c", "d")
+    def test_something(self, value):
+        return value
+
+
+@ddt(formatTestName=FormatTestName.INDEX_ONLY)
+class DummyFormatTestNameIndexOnly(object):
     """
     Dummy class to test the ddt decorator that generates test names using only
     the index.
@@ -146,18 +158,32 @@ def test_ddt():
     assert_equal(tests, 4)
 
 
-def test_ddt_index_only_true():
+def test_ddt_format_test_name_index_only():
     """
-    Test the ``ddt`` class decorator with kwargs ``indexOnly=True``
+    Test the ``ddt`` class decorator with ``INDEX_ONLY`` test name format
     """
-    tests = set(filter(_is_test, DummyIndexOnlyTestNames.__dict__))
+    tests = set(filter(_is_test, DummyFormatTestNameIndexOnly.__dict__))
     assert_equal(len(tests), 4)
 
     indexes = range(1, 5)
-    dataSets = ["a", "b", "c", "d"]  # @data inside DummyIndexOnlyTestNames
+    dataSets = ["a", "b", "c", "d"]  # @data from DummyFormatTestNameIndexOnly
     for i, d in zip(indexes, dataSets):
         assert_true("test_something_{}".format(i) in tests)
         assert_false("test_something_{}_{}".format(i, d) in tests)
+
+
+def test_ddt_format_test_name_default():
+    """
+    Test the ``ddt`` class decorator with ``DEFAULT`` test name format
+    """
+    tests = set(filter(_is_test, DummyFormatTestNameDefault.__dict__))
+    assert_equal(len(tests), 4)
+
+    indexes = range(1, 5)
+    dataSets = ["a", "b", "c", "d"]  # @data from DummyFormatTestNameDefault
+    for i, d in zip(indexes, dataSets):
+        assert_false("test_something_{}".format(i) in tests)
+        assert_true("test_something_{}_{}".format(i, d) in tests)
 
 
 def test_file_data_test_creation():

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import mock
 
-from ddt import ddt, data, file_data, FormatTestName
+from ddt import ddt, data, file_data, TestNameFormat
 from nose.tools import (
     assert_true, assert_equal, assert_false, assert_is_not_none, assert_raises
 )
@@ -32,8 +32,8 @@ class Dummy(object):
         return value
 
 
-@ddt(formatTestName=FormatTestName.DEFAULT)
-class DummyFormatTestNameDefault(object):
+@ddt(testNameFormat=TestNameFormat.DEFAULT)
+class DummyTestNameFormatDefault(object):
     """
     Dummy class to test the ddt decorator that generates test names using the
     default format (index and values).
@@ -44,8 +44,8 @@ class DummyFormatTestNameDefault(object):
         return value
 
 
-@ddt(formatTestName=FormatTestName.INDEX_ONLY)
-class DummyFormatTestNameIndexOnly(object):
+@ddt(testNameFormat=TestNameFormat.INDEX_ONLY)
+class DummyTestNameFormatIndexOnly(object):
     """
     Dummy class to test the ddt decorator that generates test names using only
     the index.
@@ -162,11 +162,11 @@ def test_ddt_format_test_name_index_only():
     """
     Test the ``ddt`` class decorator with ``INDEX_ONLY`` test name format
     """
-    tests = set(filter(_is_test, DummyFormatTestNameIndexOnly.__dict__))
+    tests = set(filter(_is_test, DummyTestNameFormatIndexOnly.__dict__))
     assert_equal(len(tests), 4)
 
     indexes = range(1, 5)
-    dataSets = ["a", "b", "c", "d"]  # @data from DummyFormatTestNameIndexOnly
+    dataSets = ["a", "b", "c", "d"]  # @data from DummyTestNameFormatIndexOnly
     for i, d in zip(indexes, dataSets):
         assert_true("test_something_{}".format(i) in tests)
         assert_false("test_something_{}_{}".format(i, d) in tests)
@@ -176,11 +176,11 @@ def test_ddt_format_test_name_default():
     """
     Test the ``ddt`` class decorator with ``DEFAULT`` test name format
     """
-    tests = set(filter(_is_test, DummyFormatTestNameDefault.__dict__))
+    tests = set(filter(_is_test, DummyTestNameFormatDefault.__dict__))
     assert_equal(len(tests), 4)
 
     indexes = range(1, 5)
-    dataSets = ["a", "b", "c", "d"]  # @data from DummyFormatTestNameDefault
+    dataSets = ["a", "b", "c", "d"]  # @data from DummyTestNameFormatDefault
     for i, d in zip(indexes, dataSets):
         assert_false("test_something_{}".format(i) in tests)
         assert_true("test_something_{}_{}".format(i, d) in tests)


### PR DESCRIPTION
**What**: I would like to add a feature to `ddt` so that test names can be generated using just the index only.

**How**: To allow that to happen, I am making use of  `kwargs` at the class-level decorator `@ddt`.  When decorating a class with `@ddt(formatTestName=FormatTestName.INDEX_ONLY)`, the boolean value will be passed to `mk_test_name()` and test names will just be index-only.

**Why**: An easier way to trigger a specific test to run.

**Testing**:  New unit test added.  Using `tox` to run against py27 and py35.
```
GLOB sdist-make: /path/masked/ddt/setup.py
py27 inst-nodeps: /path/masked/ddt/.tox/.tmp/package/1/ddt-1.3.1.zip
py27 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support,alabaster==0.7.12,Babel==2.8.0,certifi==2020.4.5.1,chardet==3.0.4,configparser==4.0.2,coverage==5.1,ddt==1.3.1,docutils==0.16,entrypoints==0.3,enum34==1.1.10,flake8==3.7.9,funcsigs==1.0.2,functools32==3.2.3.post2,idna==2.9,imagesize==1.2.0,Jinja2==2.11.2,MarkupSafe==1.1.1,mccabe==0.6.1,mock==3.0.5,nose==1.3.7,packaging==20.3,pycodestyle==2.5.0,pyflakes==2.1.1,Pygments==2.5.2,pyparsing==2.4.7,pytz==2019.3,PyYAML==5.3.1,requests==2.23.0,six==1.14.0,snowballstemmer==2.0.0,Sphinx==1.8.5,sphinxcontrib-programoutput==0.16,sphinxcontrib-websupport==1.1.2,typing==3.7.4.1,urllib3==1.25.8
py27 run-test-pre: PYTHONHASHSEED='2507378467'
py27 run-test: commands[0] | nosetests -s --with-coverage --cover-package=ddt --cover-html
.................................................................................
Name     Stmts   Miss  Cover
----------------------------
ddt.py     131      0   100%
----------------------------------------------------------------------
Ran 81 tests in 0.092s

OK
py27 run-test: commands[1] | flake8 ddt.py test
py27 run-test: commands[2] | sphinx-build -b html docs docs/_build
Running Sphinx v1.8.5
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 0 source files that are out of date
updating environment: [] 0 added, 1 changed, 0 removed
reading sources... [100%] example

/path/masked/ddt/docs/example.rst:29: WARNING: Include file u'/path/masked/ddt/test/test_data_dict_dict.json' not found or reading it failed
/path/masked/ddt/docs/example.rst:34: WARNING: Include file u'/path/masked/ddt/test/test_data_dict_dict.yaml' not found or reading it failed
/path/masked/ddt/docs/example.rst:39: WARNING: Include file u'/path/masked/ddt/test/test_data_dict.json' not found or reading it failed
/path/masked/ddt/docs/example.rst:44: WARNING: Include file u'/path/masked/ddt/test/test_data_dict.yaml' not found or reading it failed
/path/masked/ddt/docs/example.rst:49: WARNING: Include file u'/path/masked/ddt/test/test_data_list.json' not found or reading it failed
/path/masked/ddt/docs/example.rst:54: WARNING: Include file u'/path/masked/ddt/test/test_data_list.yaml' not found or reading it failed
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 50%] example
writing output... [100%] index

generating indices... genindex py-modindex
writing additional pages... search
copying static files... WARNING: html_static_path entry u'/path/masked/ddt/docs/_static' does not exist
done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 7 warnings.

The HTML pages are in docs/_build.
py35 inst-nodeps: /path/masked/ddt/.tox/.tmp/package/1/ddt-1.3.1.zip
py35 installed: coverage==5.1,ddt==1.3.1,entrypoints==0.3,flake8==3.7.9,mccabe==0.6.1,nose==1.3.7,pycodestyle==2.5.0,pyflakes==2.1.1,PyYAML==5.3.1,six==1.14.0
py35 run-test-pre: PYTHONHASHSEED='2507378467'
py35 run-test: commands[0] | nosetests -s --with-coverage --cover-package=ddt --cover-html
.................................................................................
Name     Stmts   Miss  Cover
----------------------------
ddt.py     131      0   100%
----------------------------------------------------------------------
Ran 81 tests in 0.099s

OK
py35 run-test: commands[1] | flake8 ddt.py test
___________________________________________________________________________ summary ____________________________________________________________________________
  py27: commands succeeded
  py35: commands succeeded
  congratulations :)
```