### PR TITLE
Require nose as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     author_email='carles@barrobes.com',
     url='https://github.com/datadriventests/ddt',
     py_modules=['ddt'],
+    install_requires=['nose'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The latest release (1.4.0) does a `from nose.tools import nottest` import but does not list `nose` as a dependency of `ddt`.

This PR adds `nose` as a dependency in `setup.py`