### PR TITLE
Revert "Improved code comments and renamed the test name format enum class

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -5,14 +5,16 @@
 # DDT is licensed under the MIT License, included in
 # https://github.com/datadriventests/ddt/blob/master/LICENSE.md
 
-import codecs
 import inspect
 import json
 import os
 import re
-from enum import Enum, unique
+import codecs
+from enum import (
+    Enum, unique
+)
 from functools import wraps
-from nose.tools import nottest
+
 
 try:
     import yaml
@@ -41,27 +43,22 @@ except NameError:
 
 
 @unique
-@nottest
-class TestNameFormat(Enum):
+class FormatTestName(Enum):
     """
-    An enum to configure how ``mk_test_name()`` to compose a test name.  Given
-    the following example:
+    An enum to configure how mk_test_name() to compose a test name.  Given the
+    following example:
 
-    .. code-block:: python
-
-        @data("a", "b")
-        def testSomething(self, value):
-            ...
+    @data("a", "b")
+    def testSomething(self, value):
+        ...
 
     if using just ``@ddt`` or together with ``DEFAULT``:
-
-    * ``testSomething_1_a``
-    * ``testSomething_2_b``
+        testSomething_1_a
+        testSomething_2_b
 
     if using ``INDEX_ONLY``:
-
-    * ``testSomething_1``
-    * ``testSomething_2``
+        testSomething_1
+        testSomething_2
 
     """
     DEFAULT = 0
@@ -140,7 +137,7 @@ def file_data(value, yaml_loader=None):
     return wrapper
 
 
-def mk_test_name(name, value, index=0, name_fmt=TestNameFormat.DEFAULT):
+def mk_test_name(name, value, index=0, fmt_test_name=FormatTestName.DEFAULT):
     """
     Generate a new name for a test case.
 
@@ -157,13 +154,13 @@ def mk_test_name(name, value, index=0, name_fmt=TestNameFormat.DEFAULT):
     A "trivial" value is a plain scalar, or a tuple or list consisting
     only of trivial values.
 
-    The test name format is controlled by enum ``TestNameFormat`` as well. See
+    The test name format is controlled by enum ``FormatTestName`` as well. See
     the enum documentation for further details.
     """
 
     # Add zeros before index to keep order
     index = "{0:0{1}}".format(index + 1, index_len)
-    if name_fmt is TestNameFormat.INDEX_ONLY or not is_trivial(value):
+    if fmt_test_name is FormatTestName.INDEX_ONLY or not is_trivial(value):
         return "{0}_{1}".format(name, index)
     try:
         value = str(value)
@@ -319,17 +316,17 @@ def ddt(arg=None, **kwargs):
     for each ``test_name`` key create as many methods in the list of values
     from the ``data`` key.
 
-    Decorating with the keyword argument ``testNameFormat`` can control the
+    Decorating with the keyword argument ``formatTestName`` can control the
     format of the generated test names.  For example:
 
-    - ``@ddt(testNameFormat=TestNameFormat.DEFAULT)`` will be index and values.
+    - ``@ddt(formatTestName=FormatTestName.DEFAULT)`` will be index and values.
 
-    - ``@ddt(testNameFormat=TestNameFormat.INDEX_ONLY)`` will be index only.
+    - ``@ddt(formatTestName=FormatTestName.INDEX_ONLY)`` will be index only.
 
     - ``@ddt`` is the same as DEFAULT.
 
     """
-    fmt_test_name = kwargs.get("testNameFormat", TestNameFormat.DEFAULT)
+    fmt_test_name = kwargs.get("formatTestName", FormatTestName.DEFAULT)
 
     def wrapper(cls):
         for name, func in list(cls.__dict__.items()):

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,4 @@
 -r test.txt
-nose
+
 Sphinx
 sphinxcontrib-programoutput

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import mock
 
-from ddt import ddt, data, file_data, TestNameFormat
+from ddt import ddt, data, file_data, FormatTestName
 from nose.tools import (
     assert_true, assert_equal, assert_false, assert_is_not_none, assert_raises
 )
@@ -32,8 +32,8 @@ class Dummy(object):
         return value
 
 
-@ddt(testNameFormat=TestNameFormat.DEFAULT)
-class DummyTestNameFormatDefault(object):
+@ddt(formatTestName=FormatTestName.DEFAULT)
+class DummyFormatTestNameDefault(object):
     """
     Dummy class to test the ddt decorator that generates test names using the
     default format (index and values).
@@ -44,8 +44,8 @@ class DummyTestNameFormatDefault(object):
         return value
 
 
-@ddt(testNameFormat=TestNameFormat.INDEX_ONLY)
-class DummyTestNameFormatIndexOnly(object):
+@ddt(formatTestName=FormatTestName.INDEX_ONLY)
+class DummyFormatTestNameIndexOnly(object):
     """
     Dummy class to test the ddt decorator that generates test names using only
     the index.
@@ -162,11 +162,11 @@ def test_ddt_format_test_name_index_only():
     """
     Test the ``ddt`` class decorator with ``INDEX_ONLY`` test name format
     """
-    tests = set(filter(_is_test, DummyTestNameFormatIndexOnly.__dict__))
+    tests = set(filter(_is_test, DummyFormatTestNameIndexOnly.__dict__))
     assert_equal(len(tests), 4)
 
     indexes = range(1, 5)
-    dataSets = ["a", "b", "c", "d"]  # @data from DummyTestNameFormatIndexOnly
+    dataSets = ["a", "b", "c", "d"]  # @data from DummyFormatTestNameIndexOnly
     for i, d in zip(indexes, dataSets):
         assert_true("test_something_{}".format(i) in tests)
         assert_false("test_something_{}_{}".format(i, d) in tests)
@@ -176,11 +176,11 @@ def test_ddt_format_test_name_default():
     """
     Test the ``ddt`` class decorator with ``DEFAULT`` test name format
     """
-    tests = set(filter(_is_test, DummyTestNameFormatDefault.__dict__))
+    tests = set(filter(_is_test, DummyFormatTestNameDefault.__dict__))
     assert_equal(len(tests), 4)
 
     indexes = range(1, 5)
-    dataSets = ["a", "b", "c", "d"]  # @data from DummyTestNameFormatDefault
+    dataSets = ["a", "b", "c", "d"]  # @data from DummyFormatTestNameDefault
     for i, d in zip(indexes, dataSets):
         assert_false("test_something_{}".format(i) in tests)
         assert_true("test_something_{}_{}".format(i, d) in tests)


### PR DESCRIPTION
This reverts commit 6bf51b5d7887049eda580932643a5408ca0f5e3f. It added a
needless hard dependency on nose which is a deprecated and no longer
supported anymore. We should avoid using it where possible, especially
since ddt is widely used in test suites that have nothing to do with
nose.

Fixes #83