### PR TITLE
Require enum34 for Python 2.x.

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,3 +2,4 @@
 nose
 Sphinx
 sphinxcontrib-programoutput
+enum34; python_version < '3'

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -2,3 +2,4 @@ wheel
 setuptools
 twine
 nose
+enum34; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Testing',
     ],
+    setup_requires=['enum34; python_version < "3"', 'nose'],
+    install_requires=['enum34; python_version < "3"', 'nose'],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Testing',
     ],
-    setup_requires=['enum34; python_version < "3"', 'nose'],
-    install_requires=['enum34; python_version < "3"', 'nose'],
+    setup_requires=['enum34; python_version < "3"'],
+    install_requires=['enum34; python_version < "3"'],
 )


### PR DESCRIPTION
Hi,

Thanks for your work on ddt and the rest of these wonderful testing tools!

What do you think about this trivial change that will restore Python 2.7 compatibility, since ddt still claims to support it?

Thanks in advance, and keep up the great work!

G'luck,
Peter