### PR TITLE
Remove nose dependency for good

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -34,6 +34,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with nosetests
+    - name: Test with pytest
       run: |
-        nosetests
+        pytest

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ddt.egg-info/
 .tox
 .ropeproject
 venv/
+htmlcov/

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-nosetests --with-coverage --cover-html --cover-package=ddt
+pytest --cov=ddt --cov-report html
 flake8 ddt.py test || echo "Flake8 errors"
 (cd docs; make html)

--- a/ddt.py
+++ b/ddt.py
@@ -12,7 +12,6 @@ import os
 import re
 from enum import Enum, unique
 from functools import wraps
-from nose.tools import nottest
 
 try:
     import yaml
@@ -41,7 +40,6 @@ except NameError:
 
 
 @unique
-@nottest
 class TestNameFormat(Enum):
     """
     An enum to configure how ``mk_test_name()`` to compose a test name.  Given

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -26,40 +26,40 @@ This allows you to write your tests as:
 
 Where ``test_data_dict_dict.json``:
 
-.. literalinclude:: ../test/test_data_dict_dict.json
+.. literalinclude:: ../test/data/test_data_dict_dict.json
    :language: javascript
 
 and ``test_data_dict_dict.yaml``:
 
-.. literalinclude:: ../test/test_data_dict_dict.yaml
+.. literalinclude:: ../test/data/test_data_dict_dict.yaml
    :language: yaml
 
 and ``test_data_dict.json``:
 
-.. literalinclude:: ../test/test_data_dict.json
+.. literalinclude:: ../test/data/test_data_dict.json
    :language: javascript
 
 and ``test_data_dict.yaml``:
 
-.. literalinclude:: ../test/test_data_dict.yaml
+.. literalinclude:: ../test/data/test_data_dict.yaml
    :language: yaml
 
 and ``test_data_list.json``:
 
-.. literalinclude:: ../test/test_data_list.json
+.. literalinclude:: ../test/data/test_data_list.json
    :language: javascript
 
 and ``test_data_list.yaml``:
 
-.. literalinclude:: ../test/test_data_list.yaml
+.. literalinclude:: ../test/data/test_data_list.yaml
    :language: yaml
 
-And then run them with your favourite test runner, e.g. if you use nose::
+And then run them with your favourite test runner, e.g. if you use pytest::
 
-    $ nosetests -v test/test_example.py
+    $ pytest test/test_example.py
 
 ..
-   program-output:: nosetests -v ../test/test_example.py
+   program-output:: pytest ../test/test_example.py
 
 The number of test cases actually run and reported separately has been
 multiplied.

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,3 @@
 -r test.txt
-nose
 Sphinx
 sphinxcontrib-programoutput

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,4 +1,4 @@
 wheel
 setuptools
 twine
-nose
+pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,8 @@
 codecov
 coverage
 flake8
-nose
+pytest
+pytest-cov
 six>=1.4.0
 PyYAML
 mock; python_version < '3.3'

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -410,7 +410,7 @@ def test_load_yaml_without_yaml_support():
 
         @file_data('data/test_data_dict.yaml')
         def test_file_data_yaml_dict(self, value):
-            assert_true(has_three_elements(value))
+            assert has_three_elements(value)
 
     tests = filter(_is_test, NoYAMLInstalledTest.__dict__)
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -1,7 +1,7 @@
 import os
 import json
 from sys import modules
-
+import pytest
 import six
 
 try:
@@ -10,9 +10,6 @@ except ImportError:
     import mock
 
 from ddt import ddt, data, file_data, TestNameFormat
-from nose.tools import (
-    assert_true, assert_equal, assert_false, assert_is_not_none, assert_raises
-)
 
 from test.mycode import has_three_elements
 
@@ -117,11 +114,11 @@ def test_data_decorator():
     dh_keys = set(data_hello.__dict__.keys())
     post_size = len(data_hello.__dict__)
 
-    assert_equal(post_size, pre_size + 1)
+    assert post_size == pre_size + 1
     extra_attrs = dh_keys - keys
-    assert_equal(len(extra_attrs), 1)
+    assert len(extra_attrs) == 1
     extra_attr = extra_attrs.pop()
-    assert_equal(getattr(data_hello, extra_attr), (1, 2))
+    assert getattr(data_hello, extra_attr) == (1, 2)
 
 
 def test_file_data_decorator_with_dict():
@@ -139,11 +136,12 @@ def test_file_data_decorator_with_dict():
     dh_keys = set(data_hello.__dict__.keys())
     post_size = len(data_hello.__dict__)
 
-    assert_equal(post_size, pre_size + 1)
+    assert post_size == pre_size + 1
     extra_attrs = dh_keys - keys
-    assert_equal(len(extra_attrs), 1)
+
+    assert len(extra_attrs) == 1
     extra_attr = extra_attrs.pop()
-    assert_equal(getattr(data_hello, extra_attr), ("test_data_dict.json",))
+    assert getattr(data_hello, extra_attr) == ("test_data_dict.json",)
 
 
 def _is_test(x):
@@ -155,7 +153,7 @@ def test_ddt():
     Test the ``ddt`` class decorator
     """
     tests = len(list(filter(_is_test, Dummy.__dict__)))
-    assert_equal(tests, 4)
+    assert tests == 4
 
 
 def test_ddt_format_test_name_index_only():
@@ -163,13 +161,13 @@ def test_ddt_format_test_name_index_only():
     Test the ``ddt`` class decorator with ``INDEX_ONLY`` test name format
     """
     tests = set(filter(_is_test, DummyTestNameFormatIndexOnly.__dict__))
-    assert_equal(len(tests), 4)
+    assert len(tests) == 4
 
     indexes = range(1, 5)
     dataSets = ["a", "b", "c", "d"]  # @data from DummyTestNameFormatIndexOnly
     for i, d in zip(indexes, dataSets):
-        assert_true("test_something_{}".format(i) in tests)
-        assert_false("test_something_{}_{}".format(i, d) in tests)
+        assert ("test_something_{}".format(i) in tests)
+        assert not ("test_something_{}_{}".format(i, d) in tests)
 
 
 def test_ddt_format_test_name_default():
@@ -177,13 +175,13 @@ def test_ddt_format_test_name_default():
     Test the ``ddt`` class decorator with ``DEFAULT`` test name format
     """
     tests = set(filter(_is_test, DummyTestNameFormatDefault.__dict__))
-    assert_equal(len(tests), 4)
+    assert len(tests) == 4
 
     indexes = range(1, 5)
     dataSets = ["a", "b", "c", "d"]  # @data from DummyTestNameFormatDefault
     for i, d in zip(indexes, dataSets):
-        assert_false("test_something_{}".format(i) in tests)
-        assert_true("test_something_{}_{}".format(i, d) in tests)
+        assert not ("test_something_{}".format(i) in tests)
+        assert ("test_something_{}_{}".format(i, d) in tests)
 
 
 def test_file_data_test_creation():
@@ -192,7 +190,7 @@ def test_file_data_test_creation():
     """
 
     tests = len(list(filter(_is_test, FileDataDummy.__dict__)))
-    assert_equal(tests, 2)
+    assert tests == 2
 
 
 def test_file_data_test_names_dict():
@@ -214,7 +212,7 @@ def test_file_data_test_names_dict():
         for index, name in enumerate(test_data.keys())
     ])
 
-    assert_equal(tests, created_tests)
+    assert tests == created_tests
 
 
 def test_feed_data_data():
@@ -229,7 +227,7 @@ def test_feed_data_data():
         method = getattr(obj, test)
         values.append(method())
 
-    assert_equal(set(values), set([1, 2, 3, 4]))
+    assert set(values) == set([1, 2, 3, 4])
 
 
 def test_feed_data_file_data():
@@ -244,7 +242,7 @@ def test_feed_data_file_data():
         method = getattr(obj, test)
         values.extend(method())
 
-    assert_equal(set(values), set([10, 12, 15, 15, 12, 50]))
+    assert set(values) == set([10, 12, 15, 15, 12, 50])
 
 
 def test_feed_data_file_data_missing_json():
@@ -256,7 +254,8 @@ def test_feed_data_file_data_missing_json():
     obj = JSONFileDataMissingDummy()
     for test in tests:
         method = getattr(obj, test)
-        assert_raises(ValueError, method)
+        with pytest.raises(ValueError):
+            method()
 
 
 def test_feed_data_file_data_missing_yaml():
@@ -268,7 +267,8 @@ def test_feed_data_file_data_missing_yaml():
     obj = YAMLFileDataMissingDummy()
     for test in tests:
         method = getattr(obj, test)
-        assert_raises(ValueError, method)
+        with pytest.raises(ValueError):
+            method()
 
 
 def test_ddt_data_name_attribute():
@@ -294,8 +294,8 @@ def test_ddt_data_name_attribute():
     setattr(Mytest, 'test_hello', data_hello)
 
     ddt_mytest = ddt(Mytest)
-    assert_is_not_none(getattr(ddt_mytest, 'test_hello_1_data1'))
-    assert_is_not_none(getattr(ddt_mytest, 'test_hello_2_2'))
+    assert getattr(ddt_mytest, 'test_hello_1_data1')
+    assert getattr(ddt_mytest, 'test_hello_2_2')
 
 
 def test_ddt_data_doc_attribute():
@@ -334,34 +334,12 @@ def test_ddt_data_doc_attribute():
     setattr(Mytest, 'second_test', data_hello2)
     ddt_mytest = ddt(Mytest)
 
-    assert_equal(
-        getattr(
-            getattr(ddt_mytest, 'first_test_1_case1'), '__doc__'), d1.__doc__
-    )
-    assert_equal(
-        getattr(
-            getattr(ddt_mytest, 'first_test_2_case2'), '__doc__'),
-        func_w_doc.__doc__
-    )
-    assert_equal(
-        getattr(
-            getattr(ddt_mytest, 'first_test_3'), '__doc__'),
-        func_w_doc.__doc__
-    )
-    assert_equal(
-        getattr(
-            getattr(ddt_mytest, 'second_test_1_case1'), '__doc__'), d1.__doc__
-    )
-    assert_equal(
-        getattr(
-            getattr(ddt_mytest, 'second_test_2_case2'), '__doc__'),
-        None
-    )
-    assert_equal(
-        getattr(
-            getattr(ddt_mytest, 'second_test_3'), '__doc__'),
-        None
-    )
+    assert getattr(getattr(ddt_mytest, 'first_test_1_case1'), '__doc__') == d1.__doc__
+    assert getattr(getattr(ddt_mytest, 'first_test_2_case2'), '__doc__') == func_w_doc.__doc__
+    assert getattr(getattr(ddt_mytest, 'first_test_3'), '__doc__') == func_w_doc.__doc__
+    assert getattr(getattr(ddt_mytest, 'second_test_1_case1'), '__doc__') == d1.__doc__
+    assert getattr(getattr(ddt_mytest, 'second_test_2_case2'), '__doc__') is None
+    assert getattr(getattr(ddt_mytest, 'second_test_3'), '__doc__') is None
 
 
 def test_ddt_data_unicode():
@@ -378,9 +356,9 @@ def test_ddt_data_unicode():
             def test_hello(self, val):
                 pass
 
-        assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_2_non_ascii__u2603'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_3'))
+        assert getattr(Mytest, 'test_hello_1_ascii') is not None
+        assert getattr(Mytest, 'test_hello_2_non_ascii__u2603') is not None
+        assert getattr(Mytest, 'test_hello_3') is not None
 
     elif six.PY3:
 
@@ -390,9 +368,9 @@ def test_ddt_data_unicode():
             def test_hello(self, val):
                 pass
 
-        assert_is_not_none(getattr(Mytest, 'test_hello_1_ascii'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_2_non_ascii__'))
-        assert_is_not_none(getattr(Mytest, 'test_hello_3'))
+        assert getattr(Mytest, 'test_hello_1_ascii') is not None
+        assert getattr(Mytest, 'test_hello_2_non_ascii__') is not None
+        assert getattr(Mytest, 'test_hello_3') is not None
 
 
 def test_ddt_data_object():
@@ -405,8 +383,7 @@ def test_ddt_data_object():
         @data(object())
         def test_object(self, val):
             pass
-
-    assert_is_not_none(getattr(Mytest, 'test_object_1'))
+    assert getattr(Mytest, 'test_object_1') is not None
 
 
 def test_feed_data_with_invalid_identifier():
@@ -414,15 +391,12 @@ def test_feed_data_with_invalid_identifier():
     Test that data is fed to the decorated tests
     """
     tests = list(filter(_is_test, DummyInvalidIdentifier.__dict__))
-    assert_equal(len(tests), 1)
+    assert len(tests) == 1
 
     obj = DummyInvalidIdentifier()
     method = getattr(obj, tests[0])
-    assert_equal(
-        method.__name__,
-        'test_data_with_invalid_identifier_1_32v2_g__Gmw845h_W_b53wi_'
-    )
-    assert_equal(method(), '32v2 g #Gmw845h$W b53wi.')
+    assert method.__name__ == 'test_data_with_invalid_identifier_1_32v2_g__Gmw845h_W_b53wi_'
+    assert method() == '32v2 g #Gmw845h$W b53wi.'
 
 
 @mock.patch('ddt._have_yaml', False)
@@ -443,7 +417,8 @@ def test_load_yaml_without_yaml_support():
     obj = NoYAMLInstalledTest()
     for test in tests:
         method = getattr(obj, test)
-        assert_raises(ValueError, method)
+        with pytest.raises(ValueError):
+            method()
 
 
 def test_load_yaml_with_python_tag():
@@ -463,7 +438,7 @@ def test_load_yaml_with_python_tag():
         class YamlDefaultLoaderTest(object):
             @file_data('data/test_functional_custom_tags.yaml')
             def test_cls_is_instance(self, cls, expected):
-                assert_true(isinstance(cls, str_to_type(expected)))
+                assert isinstance(cls, str_to_type(expected))
     except Exception as e:
         if not isinstance(e, ConstructorError):
             raise AssertionError()
@@ -472,7 +447,7 @@ def test_load_yaml_with_python_tag():
     class YamlFullLoaderTest(object):
         @file_data('data/test_functional_custom_tags.yaml', FullLoader)
         def test_cls_is_instance(self, instance, expected):
-            assert_true(isinstance(instance, str_to_type(expected)))
+            assert isinstance(instance, str_to_type(expected))
 
     tests = list(filter(_is_test, YamlFullLoaderTest.__dict__))
     obj = YamlFullLoaderTest()

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@ envlist = py27, py35
 
 [testenv]
 deps = 
-    nose
+    pytest
+    pytest-cov
     coverage
     flake8
     six>=1.4.0
     PyYAML
 commands = 
-    nosetests -s --with-coverage --cover-package=ddt --cover-html
+    pytest --cov=ddt --cov-report html
     flake8 ddt.py test
 
 [testenv:py27]
@@ -19,6 +20,6 @@ deps =
     Sphinx
     sphinxcontrib-programoutput
 commands = 
-    nosetests -s --with-coverage --cover-package=ddt --cover-html
+    pytest --cov=ddt --cov-report html
     flake8 ddt.py test
     sphinx-build -b html docs docs/_build


### PR DESCRIPTION
As a lot of people reported problems with hard dependency on `nose` and use of it in general (#84, #83, #82), I decided to drop it completely in favor of `pytest` for functional testing. 