### PR TITLE
Correct supported versions in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ multiple test cases.
 You can find (and fork) the project on Github_.
 
 DDT should work on Python2 and Python3, but we only officially test it for
-versions 2.7 and 3.5.
+versions 2.7 and 3.5-3.8.
 
 Contents:
 


### PR DESCRIPTION
You're testing Python up to 3.8 in your github actions. 3.5 is really ancient, so "we test only 3.5" sounds scary.