### PR TITLE
Use Yaml's UnsafeLoader for Python embedding tests

### DIFF
--- a/test/test_example.py
+++ b/test/test_example.py
@@ -151,7 +151,7 @@ if have_yaml_support:
 
     @ddt
     class YamlOnlyTestCase(unittest.TestCase):
-        @file_data('data/test_custom_yaml_loader.yaml', yaml.FullLoader)
+        @file_data('data/test_custom_yaml_loader.yaml', yaml.UnsafeLoader)
         def test_custom_yaml_loader(self, instance, expected):
             """Test with yaml tags to create specific classes to compare"""
             self.assertEqual(expected, instance)

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -440,7 +440,7 @@ def test_load_yaml_with_python_tag():
     loader allowing python tags is passed.
     """
 
-    from yaml import FullLoader
+    from yaml import UnsafeLoader
     from yaml.constructor import ConstructorError
 
     def str_to_type(class_name):
@@ -457,13 +457,13 @@ def test_load_yaml_with_python_tag():
             raise AssertionError()
 
     @ddt
-    class YamlFullLoaderTest(object):
-        @file_data('data/test_functional_custom_tags.yaml', FullLoader)
+    class YamlUnsafeLoaderTest(object):
+        @file_data('data/test_functional_custom_tags.yaml', UnsafeLoader)
         def test_cls_is_instance(self, instance, expected):
             assert isinstance(instance, str_to_type(expected))
 
-    tests = list(filter(_is_test, YamlFullLoaderTest.__dict__))
-    obj = YamlFullLoaderTest()
+    tests = list(filter(_is_test, YamlUnsafeLoaderTest.__dict__))
+    obj = YamlUnsafeLoaderTest()
 
     if not tests:
         raise AssertionError('No tests have been found.')


### PR DESCRIPTION
In newer PyYAML versions the default FullLoader has
python/object/* integration removed. One has to use
UnsafeLoader instead. see this issue for details:

https://github.com/yaml/pyyaml/issues/321