### PR TITLE
Make `index_len` argument to `idata` optional

### DIFF
--- a/ddt.py
+++ b/ddt.py
@@ -90,20 +90,30 @@ def data(*values):
     Should be added to methods of instances of ``unittest.TestCase``.
 
     """
-    return idata(values, len(str(len(values))))
+    return idata(values)
 
 
-def idata(iterable, index_len):
+def idata(iterable, index_len=None):
     """
     Method decorator to add to your test methods.
 
     Should be added to methods of instances of ``unittest.TestCase``.
 
+    :param iterable: iterable of the values to provide to the test function.
+    :param index_len: an optional integer specifying the width to zero-pad the
+        test identifier indices to.  If not provided, this will add the fewest
+        zeros necessary to make all identifiers the same length.
     """
+    if index_len is None:
+        # Avoid consuming a one-time-use generator.
+        iterable = tuple(iterable)
+        index_len = len(str(len(iterable)))
+
     def wrapper(func):
         setattr(func, DATA_ATTR, iterable)
         setattr(func, INDEX_LEN, index_len)
         return func
+
     return wrapper
 
 

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -1,6 +1,7 @@
+import itertools
 import unittest
 
-from ddt import ddt, data, file_data, unpack
+from ddt import ddt, data, file_data, idata, unpack
 from test.mycode import larger_than_two, has_three_elements, is_a_greeting
 
 try:
@@ -63,6 +64,12 @@ class FooTestCase(unittest.TestCase):
     def test_greater(self, value):
         a, b = value
         self.assertGreater(a, b)
+
+    @idata(itertools.product([0, 1, 2], [3, 4, 5]))
+    def test_iterable_argument(self, value):
+        first_value, second_value = value
+        self.assertLessEqual(first_value, 2)
+        self.assertGreaterEqual(second_value, 3)
 
     @data(annotated2([2, 1], 'Test_case_1', """Test docstring 1"""),
           annotated2([10, 5], 'Test_case_2', """Test docstring 2"""))


### PR DESCRIPTION
PR #92 added an extra argument to the `idata` decorator.  The new
`index_len` argument had no default value, and so the calling convention
was incompatible with older releases of `ddt`.  This commit makes the
second argument optional, with the previous default value inferred if it
is not supplied.  The single-argument form of `idata` will now work
again, while the newer method allowing it to be overridden is still
supported.


Fix #97.