### PR TITLE
Add async flag when wrapping async function (#111)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     timeout-minutes: 5
     strategy:
       matrix:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
     strategy:
       matrix:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
     strategy:
       matrix:
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/ddt.py
+++ b/ddt.py
@@ -215,9 +215,15 @@ def feed_data(func, new_name, test_data_docstring, *args, **kwargs):
     This internal method decorator feeds the test data item to the test.
 
     """
-    @wraps(func)
-    def wrapper(self):
-        return func(self, *args, **kwargs)
+    if inspect.iscoroutinefunction(func):
+        @wraps(func)
+        async def wrapper(self):
+            return await func(self, *args, **kwargs)
+    else:
+        @wraps(func)
+        def wrapper(self):
+            return func(self, *args, **kwargs)
+
     wrapper.__name__ = new_name
     wrapper.__wrapped__ = func
     # set docstring if exists

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
+aiounittest
 codecov
 coverage
 flake8

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -1,0 +1,11 @@
+import unittest
+
+from ddt import ddt, data
+from test.mycode import larger_than_two
+
+
+@ddt
+class TestAsync(unittest.IsolatedAsyncioTestCase):
+    @data(3, 4, 12, 23)
+    async def test_larger_than_two(self, value):
+        self.assertTrue(larger_than_two(value))

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -1,11 +1,11 @@
-import unittest
+import aiounittest
 
 from ddt import ddt, data
 from test.mycode import larger_than_two
 
 
 @ddt
-class TestAsync(unittest.IsolatedAsyncioTestCase):
+class TestAsync(aiounittest.AsyncTestCase):
     @data(3, 4, 12, 23)
     async def test_larger_than_two(self, value):
         self.assertTrue(larger_than_two(value))

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     pytest-cov
     coverage
+    aiounittest
     flake8
     six>=1.4.0
     PyYAML


### PR DESCRIPTION
Python 3.11 uses `inspect.iscoroutinefunction` to determine whether a test needs to be awaited or not. Since the wrapper created by ddt doesn't have the `async`  code flag, `iscoroutinefunction` returns `False` and it is not awaited causing the issue described in #111. 

I added a simple fix by adding the `async` code flag to the wrapper if the original function is a coroutine function. 